### PR TITLE
Clippy

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -31,7 +31,7 @@ impl Bitmap {
     pub fn read(&mut self, path: &Path) {
         let mut image = PPMImage::new(self.width, self.height);
 
-        image.read(&path);
+        image.read(path);
 
         self.width  = image.width;
         self.height = image.height;
@@ -53,6 +53,6 @@ impl Bitmap {
             }
         }
 
-        image.write(&path);
+        image.write(path);
     }
 }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -45,7 +45,7 @@ impl Canvas {
 
         let srcrect = Rect::make_wh(src.width as f32, src.height as f32);
 
-        let r2r = map_rect_to_rect_mat(&srcrect, &dst);
+        let r2r = map_rect_to_rect_mat(&srcrect, dst);
         let r2r_floats = [
             r2r.at(0), r2r.at(1), r2r.at(2),
             r2r.at(3), r2r.at(4), r2r.at(5),
@@ -58,7 +58,7 @@ impl Canvas {
 
     pub fn fill_rect(&mut self, rect: &Rect, color: &Color) {
         let mut color_shader = Shaders::from_color(*color);
-        self.shade_rect(&rect, &mut color_shader);
+        self.shade_rect(rect, &mut color_shader);
     }
 
     pub fn shade_rect<S: Shader>(&mut self, rect: &Rect, shader: &mut S) {
@@ -209,8 +209,9 @@ impl Canvas {
 
         // Triangulate convex polygon
         let mut triangles: Vec<Triangle> = Vec::with_capacity(points.len() - 2);
-        for i in 1..points.len()-1 {
-            triangles.push(Triangle::new(points[0], points[i], points[i+1]));
+
+        for window in points.windows(3) {
+            triangles.push(Triangle::new(window[0], window[1], window[2]));
         }
 
         // Shade each triangle
@@ -224,7 +225,7 @@ impl Canvas {
     }
 
     pub fn save(&mut self) {
-        let ctm = self.get_ctm().clone();
+        let ctm = self.get_ctm();
         self.ctms.push(ctm);
     }
 
@@ -233,7 +234,7 @@ impl Canvas {
     }
 
     pub fn concat(&mut self, mat: [f32; 6]) {
-        let ctm = self.get_ctm().clone();
+        let ctm = self.get_ctm();
         let len = self.ctms.len();
         self.ctms[len-1] = ctm.mul(&Matrix::new(mat));
     }
@@ -268,6 +269,6 @@ impl Canvas {
     }
 
     pub fn write(&self, path: &Path) {
-        self.bitmap.write(&path);
+        self.bitmap.write(path);
     }
 }

--- a/src/ppm.rs
+++ b/src/ppm.rs
@@ -39,7 +39,7 @@ impl PPMImage {
         // Read remaining nums into image buffer
         let nums = &nums[3..];
         for i in 0..width*height {
-            let r = nums[3*i + 0] as u8;
+            let r = nums[3*i] as u8;
             let g = nums[3*i + 1] as u8;
             let b = nums[3*i + 2] as u8;
 
@@ -50,7 +50,7 @@ impl PPMImage {
     pub fn write(&self, path: &Path) {
         // Fill up color buffer
         let (w, h) = (self.width, self.height);
-        let header = format!("P3\n");
+        let header = "P3\n".to_string();
         let dims   = format!("{} {} {}\n", w, h, 255);
         let mut bufstr = header + &dims;
         for i in 0..w*h {

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ pub fn blend(src: &Pixel, dst: &Pixel) -> Pixel {
 }
 
 // TODO: Use slices instead of vectors for read access
-pub fn blend_row(src: &Vec<Pixel>, dst: &Vec<Pixel>) -> Vec<Pixel> {
+pub fn blend_row(src: &[Pixel], dst: &[Pixel]) -> Vec<Pixel> {
     assert!(src.len() == dst.len(), "src and dst rows not the same size");
 
     let mut res: Vec<Pixel> = Vec::with_capacity(src.len());


### PR DESCRIPTION
All I did was run clippy to lint the code and implement some changes.

https://github.com/Manishearth/rust-clippy

Things of particular note:

When you make an interface like this:

```
fn foo(bar: &Vec<Thing>) ...
```

Consider this instead:

```
fn foo(bar: &[Thing]) ...
```

This is a 'slice' reference. Slices are cheap views into 'sliceable' structures.

You also had two unnecessary clones, and I replaced a for loop that indexed into an array with a 'Windows' array:
https://doc.rust-lang.org/std/slice/struct.Windows.html
